### PR TITLE
Removing 8080 as a port default

### DIFF
--- a/sdmEvalToolUI/DESCRIPTION
+++ b/sdmEvalToolUI/DESCRIPTION
@@ -19,7 +19,6 @@ Description: The goal of sdmEvalToolUI is to implement Shiny functionality
 License: Apache License 2.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Imports:
     bsicons,
     bslib,
@@ -54,3 +53,4 @@ Remotes:
 Config/testthat/edition: 3
 Depends: 
     R (>= 4.1)
+Config/roxygen2/version: 8.0.0

--- a/sdmEvalToolUI/R/app.R
+++ b/sdmEvalToolUI/R/app.R
@@ -16,7 +16,7 @@
 
 sdm_tool <- function(
   lang = "english",
-  options = list(host = "0.0.0.0", port = 8080),
+  options = list(host = "0.0.0.0", port = 7405),
   tabs = c(
     "overview",
     "predictions",

--- a/sdmEvalToolUI/R/utils_tests.R
+++ b/sdmEvalToolUI/R/utils_tests.R
@@ -65,7 +65,7 @@ test_page <- function(
     }
   }
 
-  shiny::shinyApp(ui, server, options = list(port = 8080))
+  shiny::shinyApp(ui, server, options = list(port = 7405))
 }
 
 #' Create Test App for Component Modules
@@ -121,7 +121,7 @@ test_comp <- function(
     do.call(get(paste0(module, "_server")), u)
   }
 
-  shiny::shinyApp(ui, server, options = list(port = 8080))
+  shiny::shinyApp(ui, server, options = list(port = 7405))
 }
 
 

--- a/sdmEvalToolUI/man/bslib_wrapper.Rd
+++ b/sdmEvalToolUI/man/bslib_wrapper.Rd
@@ -38,11 +38,11 @@ bslib function output
 \itemize{
 \item \code{sdm_card()} - Wrapper for \code{\link[bslib:card]{bslib::card()}}, provides defaults for \code{class},
 \code{full_screen} and \code{min_height.}
-\item \code{sdm_card_header()} - Wrapper for \code{\link[bslib:card_body]{bslib::card_header()}}, provides default
+\item \code{sdm_card_header()} - Wrapper for \code{\link[bslib:card_header]{bslib::card_header()}}, provides default
 custom class (see \code{\link[=sdm_theme]{sdm_theme()}}).
-\item \code{sdm_nav_panel()} - Wrapper for \code{\link[bslib:nav-items]{bslib::nav_panel()}}, provides default
+\item \code{sdm_nav_panel()} - Wrapper for \code{\link[bslib:nav_panel]{bslib::nav_panel()}}, provides default
 custom class (see \code{\link[=sdm_theme]{sdm_theme()}}).
-\item \code{sdm_layout_sidebar()} - Wrapper for \code{\link[bslib:sidebar]{bslib::layout_sidebar()}}, provides
+\item \code{sdm_layout_sidebar()} - Wrapper for \code{\link[bslib:layout_sidebar]{bslib::layout_sidebar()}}, provides
 defaults for \code{gap} and \code{border}.
 }
 }

--- a/sdmEvalToolUI/man/map_reactive_vals.Rd
+++ b/sdmEvalToolUI/man/map_reactive_vals.Rd
@@ -25,7 +25,7 @@ which do not need to be namespaced.}
 }
 \value{
 A reactiveValues() list, as well as having the side effect of creating
-\code{\link[shiny:observe]{shiny::observe()}} for each value in the list to be independently updated.
+\code{\link[shiny:observe]{observe()}} for each value in the list to be independently updated.
 }
 \description{
 Tracks interactive inputs from map selections. Depending on the origin,

--- a/sdmEvalToolUI/man/sdmEvalToolUI-package.Rd
+++ b/sdmEvalToolUI/man/sdmEvalToolUI-package.Rd
@@ -13,6 +13,7 @@ The goal of sdmEvalToolUI is to implement Shiny functionality according to the S
 
 Authors:
 \itemize{
+  \item Peter Solymos \email{psolymos@gmail.com} (\href{https://orcid.org/0000-0001-7337-1740}{ORCID})
   \item Steffi LaZerte \email{sel@steffilazerte.ca} (\href{https://orcid.org/0000-0002-7690-8360}{ORCID})
 }
 

--- a/sdmEvalToolUI/man/sdm_tool.Rd
+++ b/sdmEvalToolUI/man/sdm_tool.Rd
@@ -6,7 +6,7 @@
 \usage{
 sdm_tool(
   lang = "english",
-  options = list(host = "0.0.0.0", port = 8080),
+  options = list(host = "0.0.0.0", port = 7405),
   tabs = c("overview", "predictions", "observations", "model", "predictors",
     "model_metadata", "summary"),
   user = NULL,

--- a/sdmEvalToolUI/man/ui_questions_update.Rd
+++ b/sdmEvalToolUI/man/ui_questions_update.Rd
@@ -16,7 +16,7 @@ All possible Spatial ID options for spatial inputs choices. Generally
 passed in as ReactiveVal (see \code{\link[=mod_page_template_spatial_server]{mod_page_template_spatial_server()}}.}
 }
 \value{
-Nothing. Performs Javascript update (see \code{\link[shiny:updateSelectInput]{shiny::updateSelectizeInput()}}).
+Nothing. Performs Javascript update (see \code{\link[shiny:updateSelectizeInput]{updateSelectizeInput()}}).
 }
 \description{
 Because there many be many possible selections for Spatial inputs, we use


### PR DESCRIPTION
The port 8080 is being blocked on our computers for some reason. It was causing the app to fail to initialize.

Shiny recommends a random port between 3000:8000 (https://shiny.posit.co/r/reference/shiny/1.8.0/runapp.html), so I've just chosen another port that works for me (7405). 

